### PR TITLE
fix: update upload-artifact to v5 and replace deprecated macos-13 runner

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,8 +17,6 @@ jobs:
             os: ubuntu-24.04
           - rid: linux-arm64
             os: ubuntu-24.04-arm
-          - rid: osx-x64
-            os: macos-13
           - rid: osx-arm64
             os: macos-15
           - rid: win-x64
@@ -49,7 +47,7 @@ jobs:
         run: Compress-Archive -Path publish/* -DestinationPath funurl-${{ matrix.rid }}.zip
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: funurl-${{ matrix.rid }}
           path: funurl-${{ matrix.rid }}.zip
@@ -58,7 +56,7 @@ jobs:
         run: dotnet pack funURL.CLI -c Release -r ${{ matrix.rid }} -o nupkgs
 
       - name: Upload nupkg
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: nupkg-${{ matrix.rid }}
           path: nupkgs/*.nupkg

--- a/.gitignore
+++ b/.gitignore
@@ -489,3 +489,6 @@ $RECYCLE.BIN/
 
 # Test files
 urls.txt
+
+
+.claude/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed macOS x64 from the build matrix, restricting platform support accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->